### PR TITLE
addressing races in concurrent process startup 

### DIFF
--- a/app/meson.build
+++ b/app/meson.build
@@ -30,6 +30,7 @@ apps = [
         'test-flow-perf',
         'test-gpudev',
         'test-mldev',
+        'test-mp',
         'test-pipeline',
         'test-pmd',
         'test-regex',

--- a/app/test-mp/main.c
+++ b/app/test-mp/main.c
@@ -1,0 +1,49 @@
+#include <stdio.h>
+#include <string.h>
+
+#include <rte_malloc.h>
+#include <rte_launch.h>
+#include <rte_eal.h>
+
+rte_atomic32_t g_count;
+
+static int
+done(const struct rte_mp_msg *msg __rte_unused, const void *arg __rte_unused)
+{
+	rte_atomic32_dec(&g_count);
+	return 0;
+}
+
+int
+main(int argc, char **argv)
+{
+	void *p;
+	int ret;
+
+	ret = rte_eal_init(argc, argv);
+	assert(ret >= 0);
+
+	rte_atomic32_set(&g_count, atoi(argv[++ret]));
+
+	if (rte_eal_process_type() == RTE_PROC_PRIMARY) {
+		ret = rte_mp_action_register("done", done);
+		assert(ret == 0);
+	}
+
+	p = rte_malloc(NULL, 0x1000000, 0x1000);
+	assert(p);
+
+	if (rte_eal_process_type() == RTE_PROC_PRIMARY) {
+		uint64_t timeout = rte_rdtsc() + 5 * rte_get_tsc_hz();
+
+		while (rte_atomic32_read(&g_count) > 0)
+			assert(rte_rdtsc() < timeout);
+	} else {
+		struct rte_mp_msg msg = { .name = "done" };
+
+		rte_mp_sendmsg(&msg);
+	}
+
+	rte_eal_cleanup();
+	return 0;
+}

--- a/app/test-mp/meson.build
+++ b/app/test-mp/meson.build
@@ -1,0 +1,8 @@
+if is_windows
+    build = false
+    reason = 'not supported on Windows'
+    subdir_done()
+endif
+
+sources = files('main.c')
+deps = ['eal'] # , 'mempool', 'net', 'mbuf', 'ethdev', 'cmdline']

--- a/app/test-mp/run.sh
+++ b/app/test-mp/run.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+logdir=/tmp/dpdk_test_mp
+repeat=1
+lastcore=$(($(nproc) - 1))
+log=1
+
+while getopts p:r:lL:d op; do case $op in
+    p) lastcore=$OPTARG ;;
+    r) repeat=$OPTARG ;;
+    L) logdir=$OPTARG ;;
+    l) log=0 ;;
+    d) debug=1 ;;
+esac done
+shift $((OPTIND-1))
+
+test=$1
+logpath=$logdir/$(date +%y%m%d-%H%M%S)
+
+rm -f core.*
+pkill dpdk-test-mp
+
+for j in $(seq $repeat) ; do
+    [ $log ] && mkdir -p $logpath/$j
+    for i in $(seq 0 $lastcore) ; do
+	args="-l $i --file-prefix=dpdk1 --proc-type=auto"
+	if [ $debug ] ; then
+	    args="$args --log-level=lib.eal:8"
+	fi
+	if [ $log ] ; then
+	    $test $args $lastcore >$logpath/$j/$i.log 2>&1 &
+	else
+	    $test $args $lastcore &
+	fi
+    done
+    wait || break
+    [ $(ls core.* 2>/dev/null | wc -l) -gt 0 ] && break
+    echo iteration $j passed
+done

--- a/lib/eal/common/eal_common_memzone.c
+++ b/lib/eal/common/eal_common_memzone.c
@@ -447,6 +447,18 @@ rte_eal_memzone_init(void)
 	return ret;
 }
 
+void
+rte_eal_memzone_cleanup(void)
+{
+	struct rte_mem_config *mcfg;
+
+	mcfg = rte_eal_get_configuration()->mem_config;
+
+	if (rte_eal_process_type() == RTE_PROC_PRIMARY) {
+		rte_fbarray_destroy(&mcfg->memzones);
+	}
+}
+
 /* Walk all reserved memory zones */
 void rte_memzone_walk(void (*func)(const struct rte_memzone *, void *),
 		      void *arg)

--- a/lib/eal/common/eal_common_proc.c
+++ b/lib/eal/common/eal_common_proc.c
@@ -593,7 +593,7 @@ open_socket_fd(void)
 }
 
 static void
-close_socket_fd(int fd)
+remove_socket_fd(int fd)
 {
 	char path[PATH_MAX];
 
@@ -672,9 +672,9 @@ rte_mp_channel_cleanup(void)
 	if (fd < 0)
 		return;
 
+	remove_socket_fd(fd);
 	pthread_cancel((pthread_t)mp_handle_tid.opaque_id);
 	rte_thread_join(mp_handle_tid, NULL);
-	close_socket_fd(fd);
 }
 
 /**

--- a/lib/eal/common/eal_private.h
+++ b/lib/eal/common/eal_private.h
@@ -81,6 +81,11 @@ struct rte_config *rte_eal_get_configuration(void);
 int rte_eal_memzone_init(void);
 
 /**
+ * Cleanup the memzone subsystem (private to eal).
+ */
+void rte_eal_memzone_cleanup(void);
+
+/**
  * Fill configuration with number of physical and logical processors
  *
  * This function is private to EAL.

--- a/lib/eal/common/hotplug_mp.c
+++ b/lib/eal/common/hotplug_mp.c
@@ -428,6 +428,9 @@ int eal_dev_hotplug_request_to_secondary(struct eal_dev_mp_req *req)
 			if (req->t == EAL_DEV_REQ_TYPE_ATTACH &&
 				resp->result == -EEXIST)
 				continue;
+			if (req->t == EAL_DEV_REQ_TYPE_ATTACH &&
+				resp->result == -ENOTSUP)
+				continue;
 			if (req->t == EAL_DEV_REQ_TYPE_DETACH &&
 				resp->result == -ENOENT)
 				continue;

--- a/lib/eal/linux/eal.c
+++ b/lib/eal/linux/eal.c
@@ -1375,6 +1375,7 @@ rte_eal_cleanup(void)
 	eal_trace_fini();
 	eal_mp_dev_hotplug_cleanup();
 	rte_eal_alarm_cleanup();
+	rte_eal_memzone_cleanup();
 	/* after this point, any DPDK pointers will become dangling */
 	rte_eal_memory_detach();
 	rte_eal_malloc_heap_cleanup();

--- a/lib/eal/linux/eal.c
+++ b/lib/eal/linux/eal.c
@@ -360,7 +360,7 @@ eal_proc_type_detect(void)
 		 * keep that open and don't close it to prevent a race condition
 		 * between multiple opens.
 		 */
-		if (((mem_cfg_fd = open(pathname, O_RDWR)) >= 0) &&
+		if (((mem_cfg_fd = open(pathname, O_RDWR | O_CREAT, 0600)) >= 0) &&
 				(fcntl(mem_cfg_fd, F_SETLK, &wr_lock) < 0))
 			ptype = RTE_PROC_SECONDARY;
 	}


### PR DESCRIPTION
In the process of initiating multiple processes concurrently, specifically with 
automatic detection of the primary process, certain race conditions have been   
identified. This patch series introduces a straightforward test that showcases  
the issue and subsequently addresses the problems surfaced by the test. These   
fixes aim to ensure the robust and secure utilization of DPDK within intricate  
solutions that involve starting processes with job orchestrators such as Slurm  
or Hadoop YARN.